### PR TITLE
fix: remove test execution from build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Build Application
         run: yarn build:dirty
 
-      - name: Unit Tests
-        run: yarn test:ci
+#      - name: Unit Tests
+#        run: yarn test:ci
 
       - name: Log in to the Container registry
         uses: docker/login-action@v1


### PR DESCRIPTION
In the course of https://github.com/catenax-ng/tx-portal-frontend-registration/pull/52 the few tests were remove because they were obsolete or without any value by now.
So in the build workflow no tests are found, and this causes an error.
