### PR TITLE
chore: fix cve-2023-23916 and update workflows

### DIFF
--- a/.conf/Dockerfile
+++ b/.conf/Dockerfile
@@ -28,8 +28,8 @@ COPY ./scripts/inject-dynamic-env.sh /docker-entrypoint.d/00-inject-dynamic-env.
 RUN chmod +x /docker-entrypoint.d/00-inject-dynamic-env.sh
 # Install bash for env variables inject script
 RUN apk update && apk add --no-cache bash
-# temp fix for CVE-2023-0286
-RUN apk upgrade --no-cache libssl3 libcrypto3
+# temp fix for CVE-2023-23916
+RUN apk upgrade --no-cache curl libcurl
 # Make nginx owner of /usr/share/nginx/html/ and change to nginx user
 RUN chown -R 101:101 /usr/share/nginx/html/
 USER 101

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,6 @@ on:
   push:
     branches:
       - 'dev'
-      - 'main'
 
 env:
   REGISTRY: ghcr.io
@@ -75,7 +74,7 @@ jobs:
           file: .conf/Dockerfile
           push: true
           # build tag :dev with commit-sha and latest
-          tags: ${{ steps.meta.outputs.tags }}_${{ env.COMMIT_SHA }}, ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.COMMIT_SHA }}, ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev
           labels: ${{ steps.meta.outputs.labels }}
 
   auth-and-dispatch:
@@ -101,5 +100,5 @@ jobs:
             --url https://api.github.com/repos/catenax-ng/tx-portal-cd/actions/workflows/portal-registration-image-update.yml/dispatches \
             --header "authorization: Bearer $TOKEN" \
             --header "Accept: application/vnd.github.v3+json" \
-            --data '{"ref":"helm-environments", "inputs": { "new-image":"${{ github.ref_name }}_${{ env.COMMIT_SHA }}" }}' \
+            --data '{"ref":"helm-environments", "inputs": { "new-image":"${{ env.COMMIT_SHA }}" }}' \
             --fail

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -21,7 +21,7 @@ name: "KICS"
 
 on:
   push:
-    branches: [main, master]
+    branches: [main, dev]
   # pull_request:
   # The branches below must be a subset of the branches above
   # branches: [main, master]

--- a/.github/workflows/trivy-dev.yml
+++ b/.github/workflows/trivy-dev.yml
@@ -20,11 +20,11 @@
 # Depending on the location of your Docker container
 # you need to change the path to the specific Docker registry.
 #
-name: "Trivy"
+name: "Trivy Dev"
 
 on:
   push:
-    branches: [main, master]
+    branches: [ dev ]
   # pull_request:
   # The branches below must be a subset of the branches above
   # branches: [ main, master ]
@@ -39,7 +39,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: catenax-ng/tx-portal-frontend
 
 jobs:
   analyze-config:
@@ -91,7 +91,7 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           # Path to Docker image
-          image-ref: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+          image-ref: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev"
           format: "sarif"
           output: "trivy-results2.sarif"
           exit-code: "1"

--- a/.github/workflows/trivy-stable.yml
+++ b/.github/workflows/trivy-stable.yml
@@ -1,0 +1,104 @@
+###############################################################
+# Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
+
+# Depending on the location of your Docker container
+# you need to change the path to the specific Docker registry.
+#
+name: "Trivy Stable"
+
+on:
+  push:
+    branches: [ main ]
+  # pull_request:
+  # The branches below must be a subset of the branches above
+  # branches: [ main, master ]
+  # paths-ignore:
+  #   - "**/*.md"
+  #   - "**/*.txt"
+  schedule:
+    # Once a day
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+  # Trigger manually
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: catenax-ng/tx-portal-frontend
+
+jobs:
+  analyze-config:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Run Trivy vulnerability scanner in repo mode
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: "config"
+          # ignore-unfixed: true
+          exit-code: "1"
+          hide-progress: false
+          format: "sarif"
+          output: "trivy-results1.sarif"
+          severity: "CRITICAL,HIGH"
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        if: always()
+        with:
+          sarif_file: "trivy-results1.sarif"
+
+  analyze-portal-frontend-registration:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # It's also possible to scan your private registry with Trivy's built-in image scan.
+      # All you have to do is set ENV vars.
+      # Docker Hub needs TRIVY_USERNAME and TRIVY_PASSWORD.
+      # You don't need to set ENV vars when downloading from a public repository.
+      # For public images, no ENV vars must be set.
+      - name: Run Trivy vulnerability scanner
+        if: always()
+        uses: aquasecurity/trivy-action@master
+        with:
+          # Path to Docker image
+          image-ref: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+          format: "sarif"
+          output: "trivy-results2.sarif"
+          exit-code: "1"
+          severity: "CRITICAL,HIGH"
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: "trivy-results2.sarif"


### PR DESCRIPTION
- add temp fix for CVE-2023-23916
- remove obsolete temp fix for CVE-2023-0286
- run kics scan on dev
- limit build workflow to dev
- introduce separate trivy scan for dev